### PR TITLE
Adding MSP101 tab + link to msp-interest mailing-list

### DIFF
--- a/_templates/default.html
+++ b/_templates/default.html
@@ -19,6 +19,7 @@
         <li><a class="{{section.news}}" href="{{rootPath}}news.html">News</a></li>
         <li><a class="{{section.people}}" href="{{rootPath}}people.html">People</a></li>
         <li><a class="{{section.grants-and-projects}}" href="{{rootPath}}grants-and-projects.html">Grants and Projects</a></li>
+        <li><a class="{{section.msp101}}" href="{{rootPath}}msp101.html">MSP101</a></li>
       </ul>
 
       <div class="sidebar">
@@ -26,10 +27,10 @@
           <h3>News</h3>
           <dl class="events">
   <dt>29th July 2013</dt>
-  <dd><a name="lecturer2"></a> We are currently looking for a new 
+  <dd><a name="lecturer2"></a> We are currently looking for a new
    <a
   href = "http://www.mis.strath.ac.uk/Personnel/open/1432013.pdf"> Lecturer or Senior Lecturer
-  </a> within the MSP group. See the above link for how to apply (deadline is 8 September 2013). 
+  </a> within the MSP group. See the above link for how to apply (deadline is 8 September 2013).
 </dd>
 
           </dl>
@@ -41,6 +42,9 @@
             <dt>About the group</dt>
             <dd>
               <a href="mailto:Conor.McBride@strath.ac.uk">Conor.McBride@strath.ac.uk</a>
+              <br />
+              <a href="https://lists.cis.strath.ac.uk/mailman/listinfo/msp-interest">
+                msp-interest</a> mailing-list
             </dd>
 
             <dt>About these web pages</dt>

--- a/msp101.html
+++ b/msp101.html
@@ -3,7 +3,10 @@
 <h2>MSP101</h2>
 
 <p>MSP101 is an ongoing series of informal talks given on Wednesday
-mornings by visiting academics or members of the MSP group.</p>
+mornings by visiting academics or members of the MSP group. They are
+usually announced on the
+<a href="https://lists.cis.strath.ac.uk/mailman/listinfo/msp-interest">
+msp-interest</a> mailing-list.</p>
 
 <h2>List of previous talks</h2>
 


### PR DESCRIPTION
We thought it'd be nice to keep track of the 101s on the website & store wee abstracts / links to extra content.
