### PR TITLE
[ ci ] use GHC version as a cache key

### DIFF
--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -44,7 +44,7 @@ jobs:
             ~/_dist
             ~/.cabal/bin/
           key: cabal-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ github.sha }}
-          restore-keys: cabal-${{ env.GHC_VERSION }}-${{ runner.os }}
+          restore-keys: cabal-${{ runner.os }}-${{ env.GHC_VERSION }}
 
       ##### Installation #######################################
       - name: Install Generate[101]

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -27,6 +27,7 @@ jobs:
           filters: |
             haskell-changed:
               - '*.hs'
+              - '.github/workflows/generate-website.yml'
 
       - name: Install cabal and GHC
         if: github.event_name != 'schedule' && steps.changes.outputs.haskell-changed == 'true'

--- a/.github/workflows/generate-website.yml
+++ b/.github/workflows/generate-website.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: 10 14 * * * # 10 minutes after 101 slot starts (UTC timezone)
 
+env:
+  GHC_VERSION: 9.6
+
 jobs:
 
   build-and-deploy:
@@ -29,7 +32,7 @@ jobs:
         if: github.event_name != 'schedule' && steps.changes.outputs.haskell-changed == 'true'
         uses: haskell-actions/setup@v2
         with:
-          ghc-version: '9.6'
+          ghc-version: ${{ env.GHC_VERSION }}
           cabal-version: 'latest'
 
       - name: Cache cabal and executables
@@ -39,8 +42,8 @@ jobs:
             ~/.cabal/store
             ~/_dist
             ~/.cabal/bin/
-          key: cabal-${{ runner.os }}-${{ github.sha }}
-          restore-keys: cabal-${{ runner.os }}
+          key: cabal-${{ runner.os }}-${{ env.GHC_VERSION }}-${{ github.sha }}
+          restore-keys: cabal-${{ env.GHC_VERSION }}-${{ runner.os }}
 
       ##### Installation #######################################
       - name: Install Generate[101]

--- a/Generate101.hs
+++ b/Generate101.hs
@@ -27,6 +27,7 @@ prettyEncode ts file = do
   BS.writeFile file $ encodePretty' cfg ts
 -}
 
+main :: IO ()
 main = do
   ts <- talks
   let ts' = filter (not . cancelled . snd) ts


### PR DESCRIPTION
This should reduce the cache size from ~240M at the moment to ~120M because we'll evict the content that came from prior GHC versions.